### PR TITLE
Fix typos in tooltips and manual

### DIFF
--- a/Source/gui/OscComponent.cpp
+++ b/Source/gui/OscComponent.cpp
@@ -244,7 +244,7 @@ OscComponent::OscComponent(OdinAudioProcessor &p_processor,
 	m_hp.setTextBoxStyle(Slider::NoTextBox, false, 0, 0);
 	m_hp.setTextValueSuffix(" Hz");
 	m_hp.setNumDecimalPlacesToDisplay(0);
-	m_hp.setKnobTooltip("The frequency of\nthe highspass filter which\nis applied to the noise");
+	m_hp.setKnobTooltip("The frequency of\nthe highpass filter which\nis applied to the noise");
 	addChildComponent(m_hp);
 
 	m_position.setSliderStyle(Slider::RotaryVerticalDrag);
@@ -670,7 +670,7 @@ OscComponent::OscComponent(OdinAudioProcessor &p_processor,
 	m_modulation_source.setIncrementValue(10, 1);
 	m_modulation_source.setDecrementValue(1, 10);
 	m_modulation_source.setDecrementValue(10, 1);
-	m_modulation_source.setTooltip("Select wich source modulates the wavetable position");
+	m_modulation_source.setTooltip("Select which source modulates the wavetable position");
 	m_modulation_source.OnValueChange = [&](int p_new_value) {
 		m_value_tree.state.getChildWithName("osc").setProperty(
 		    m_modulation_source_identifier, (float)p_new_value, nullptr);

--- a/Source/gui/ReverbComponent.cpp
+++ b/Source/gui/ReverbComponent.cpp
@@ -51,13 +51,13 @@ ReverbComponent::ReverbComponent(AudioProcessorValueTreeState &vts, bool p_is_st
 	m_EQ_gain.setTextBoxStyle(Slider::NoTextBox, false, 0, 0);
 	m_EQ_gain.setTextValueSuffix(" dB");
 	m_EQ_gain.setNumDecimalPlacesToDisplay(1);
-	m_EQ_gain.setKnobTooltip("Sets the gain of the build in equalizer");
+	m_EQ_gain.setKnobTooltip("Sets the gain of the built in equalizer");
 	addAndMakeVisible(m_EQ_gain);
 
 	m_EQ_freq.setSliderStyle(Slider::RotaryVerticalDrag);
 	m_EQ_freq.setTextValueSuffix(" Hz");
 	m_EQ_freq.setTextBoxStyle(Slider::NoTextBox, false, 0, 0);
-	m_EQ_freq.setKnobTooltip("Sets the frequency of the build in eqalizer");
+	m_EQ_freq.setKnobTooltip("Sets the frequency of the built in equalizer");
 	addAndMakeVisible(m_EQ_freq);
 
 	//m_ducking.setSliderStyle(Slider::RotaryVerticalDrag);

--- a/manual/Arpeggiator.tex
+++ b/manual/Arpeggiator.tex
@@ -5,7 +5,7 @@
     \includegraphics[width=\textwidth]{graphics/arpeggiator.png}
 \end{center}
 
-The Arpeggiator \& Step Sequencer is a tool which is able to automatically play complex rhytmic sequences from a given set of input notes. Activating this module overrides the notes you're inputting into the synthesizer and generates note sequences itself.
+The Arpeggiator \& Step Sequencer is a tool which is able to automatically play complex rhythmic sequences from a given set of input notes. Activating this module overrides the notes you're inputting into the synthesizer and generates note sequences itself.
 
 \begin{tcolorbox}[colback=yellow!10!white,
     colframe=white!20!black,

--- a/manual/FX.tex
+++ b/manual/FX.tex
@@ -29,7 +29,7 @@ You can also \fat{change the order of the modules}, by drag'n'dropping their nam
     \includegraphics[width=0.5\textwidth]{graphics/delay.png}
 \end{center}
 
-A delay is a module capable of producing an 'echo' effect: The signal is fed into a delay-line, which outputs the signal again after a set amount of time again. The output of the delay line can also be fed back in, allowing a chain of attenuating echos. By controlling the delay time and feeback parameters, a wide variety of effects can be achieved. The Delay module in Odin 2 goes a step further and offers several additional features.
+A delay is a module capable of producing an 'echo' effect: The signal is fed into a delay-line, which outputs the signal again after a set amount of time again. The output of the delay line can also be fed back in, allowing a chain of attenuating echos. By controlling the delay time and feedback parameters, a wide variety of effects can be achieved. The Delay module in Odin 2 goes a step further and offers several additional features.
 
 \audioparameter{Delay Time}{1}{1}{
     Controls the time the delay line takes to output the sound again. Depending on the parameter "Delay Sync", this is either a dial for continuous values in Hz, or a custom selector to sync the time to the beat. This selector allows for arbitrary fractions of the current host BPM, for example 5/16th notes:
@@ -77,7 +77,7 @@ Unlike the other FX modules, the Delay features a separate Dry and Wet control t
     \includegraphics[width=0.5\textwidth]{graphics/chorus.png}
 \end{center}
 
-The Chorus module is a delay based effect capable of thickening sounds. The generated sound resembles that of a slightly detuned ensemble, hence the name chorus. Internally, the Chorus module uses a delay line, which is read from at two diferent positions. The delay times are modulated by an internal Low Frequency Oscillator (LFO). This slightly detunes the result resulting in the Chorus sound. The LFOs for the left and right channel are phase-offset by 90$^{\circ}$ to spread the sound in the stereo field.
+The Chorus module is a delay based effect capable of thickening sounds. The generated sound resembles that of a slightly detuned ensemble, hence the name chorus. Internally, the Chorus module uses a delay line, which is read from at two different positions. The delay times are modulated by an internal Low Frequency Oscillator (LFO). This slightly detunes the result resulting in the Chorus sound. The LFOs for the left and right channel are phase-offset by 90$^{\circ}$ to spread the sound in the stereo field.
 
 \audioparameter{Chorus Rate}{1}{1}{
     Controls the speed of the internal LFO. Depending on the parameter "Chorus Sync", this is either a dial for continuous values in Hz, or a custom selector to sync the time to the beat. This selector allows for arbitrary fractions of the current host BPM, for example 5/16th notes:
@@ -107,7 +107,7 @@ The Chorus module is a delay based effect capable of thickening sounds. The gene
 \begin{center}
     \includegraphics[width=0.5\textwidth]{graphics/phaser.png}
 \end{center}
-The phaser module introduces movement to the sound by applying a subtle "windy" character. The internal structure consists of a series of allpass filters: These filters do not alter the amplitude like the filters from Chapter \ref{filters}, but only shifts the phase of some frequencies. By adding the phase-shifted signal back onto the original signal, some of the frequencies get boosted, attenuated or eliminated entirely via phase-cancellation. The characteristic of the allpass-filters is continuously modulated by an internal Low Frequency Oscillator (LFO), which makes for the movemnet in the sound. The LFOs for the left and right channel are phase-offset by 90$^{\circ}$ to spread the sound in the stereo field.
+The phaser module introduces movement to the sound by applying a subtle "windy" character. The internal structure consists of a series of allpass filters: These filters do not alter the amplitude like the filters from Chapter \ref{filters}, but only shifts the phase of some frequencies. By adding the phase-shifted signal back onto the original signal, some of the frequencies get boosted, attenuated or eliminated entirely via phase-cancellation. The characteristic of the allpass-filters is continuously modulated by an internal Low Frequency Oscillator (LFO), which makes for the movement in the sound. The LFOs for the left and right channel are phase-offset by 90$^{\circ}$ to spread the sound in the stereo field.
 
 \audioparameter{Phaser Rate}{1}{1}{
     Controls the speed of the internal LFO. Depending on the parameter "Phaser Sync", this is either a dial for continuous values in Hz, or a custom selector to sync the time to the beat. This selector allows for arbitrary fractions of the current host BPM, for example 5/16th notes:
@@ -134,7 +134,7 @@ The phaser module introduces movement to the sound by applying a subtle "windy" 
 }
 
 \audioparameter{Phaser DryWet}{1}{1}{
-    Controls how much of the phase-shifted signal is added to the input signal, thereby controling the strength of the effect.
+    Controls how much of the phase-shifted signal is added to the input signal, thereby controlling the strength of the effect.
 }
 
 \section{Flanger}

--- a/manual/GlobalSettings.tex
+++ b/manual/GlobalSettings.tex
@@ -70,7 +70,7 @@ The controls for Unison can be found in the top-left corner of the GUI.
 \section{Microtuning}
 \label{microtuning}
 
-Starting from version 2.3, Odin 2 supports microtuning. This feateare can be used from subtle changes, like retuning the instrument to a different base frequency to a complete remapping of the keyboard.
+Starting from version 2.3, Odin 2 supports microtuning. This feature can be used from subtle changes, like retuning the instrument to a different base frequency to a complete remapping of the keyboard.
 You can find the Tuning dropdown on top of the GUI:
 
 \begin{center}

--- a/manual/Introduction.tex
+++ b/manual/Introduction.tex
@@ -56,7 +56,7 @@ Odin 2 is a mighty kick-ass semimodular subtractive synthesizer plugin, which is
 Don't let anybody tell you otherwise. 
 
 \vspace{1mm}
-The design approach of Odin 2 lets you choose from a large variety of modules, which can be mixed and matched for virtually endless sonic capabilities. Three Oscillators, three Filters, a dedicated Distortion, four onboard FX, four Envelopes, four LFOs ... the list continues: Modulate tons of parameters with the big-ass Modulation Matrix, use the Arpeggiator and Step Sequencer to generate rhythms and musical ideas, theres Unison, a XY-Pad, you can draw your oscillator waves, or maybe your spectra?
+The design approach of Odin 2 lets you choose from a large variety of modules, which can be mixed and matched for virtually endless sonic capabilities. Three Oscillators, three Filters, a dedicated Distortion, four onboard FX, four Envelopes, four LFOs ... the list continues: Modulate tons of parameters with the big-ass Modulation Matrix, use the Arpeggiator and Step Sequencer to generate rhythms and musical ideas, there's Unison, a XY-Pad, you can draw your oscillator waves, or maybe your spectra?
 
 \vspace{2mm}
 This text is supposed to fit on one page, so I can't really talk about everything Odin 2 has to offer,

--- a/manual/ModulationMatrix.tex
+++ b/manual/ModulationMatrix.tex
@@ -559,7 +559,7 @@ This is an overview of all available modulation destinations in Odin 2. The colu
             Same as moving the control knob by a value of -1.
         }
         \moddest{Phaser Drywet}{M}{
-            Modulates the ratio of processed and unprocess signals output by the Phaser module.
+            Modulates the ratio of processed and unprocessed signals output by the Phaser module.
         }{
             Same as moving the control knob by a value of +1.
         }{
@@ -588,7 +588,7 @@ This is an overview of all available modulation destinations in Odin 2. The colu
             Same as moving the control knob by a value of -1.
         }
         \moddest{Chorus Drywet}{M}{
-            Modulates the ratio of processed and unprocess signals output by the Chorus module.
+            Modulates the ratio of processed and unprocessed signals output by the Chorus module.
         }{
             Same as moving the control knob by a value of +1.
         }{
@@ -617,7 +617,7 @@ This is an overview of all available modulation destinations in Odin 2. The colu
             Same as moving the control knob by a value of -1.
         }
         \moddest{Flanger Drywet}{M}{
-            Modulates the ratio of processed and unprocess signals output by the Flanger module.
+            Modulates the ratio of processed and unprocessed signals output by the Flanger module.
         }{
             Same as moving the control knob by a value of +1.
         }{

--- a/manual/Modulators.tex
+++ b/manual/Modulators.tex
@@ -51,7 +51,7 @@ The following graphic shows the structure of an ADSR envelope:
 }
 
 \audioparameter{Sustain}{1}{1}{
-    The Sustain determines the level that the Evelope will fall to after the Decay section. Note that the Sustain section will be active after Decay finished for as long as the MIDI-key is not released.
+    The Sustain determines the level that the Envelope will fall to after the Decay section. Note that the Sustain section will be active after Decay finished for as long as the MIDI-key is not released.
 }
 
 \audioparameter{Release}{1}{1}{

--- a/manual/Oscillators.tex
+++ b/manual/Oscillators.tex
@@ -272,7 +272,7 @@ When you press the apply button, the waveform is processed into the spectral dom
 \begin{center}
     \includegraphics[width=0.5\textwidth]{graphics/specdraw_osc.png}
 \end{center}
-The SpecDraw Osc opens the sonic capabilities with some \fat{additive synthesis}. Unlike subtractive synthesis, where you filter frequencies from harmonically rich waves, additive synthesis lets you build a sound by stacking up individual harmonics. The n-th harmonic is a sine wave which has n-times the frequency of the base note. The SpecDraw Osc lets you draw the amplitude of these sine waves. The left-most bar represents the fundamental. In the initial state, only this bar ist present, resulting in an overall sine wave osc. As you bring more overtones, the sound gets richer. Additive synthesis is capable of creating timbres which are not possible with subtractive synthesis.
+The SpecDraw Osc opens the sonic capabilities with some \fat{additive synthesis}. Unlike subtractive synthesis, where you filter frequencies from harmonically rich waves, additive synthesis lets you build a sound by stacking up individual harmonics. The n-th harmonic is a sine wave which has n-times the frequency of the base note. The SpecDraw Osc lets you draw the amplitude of these sine waves. The left-most bar represents the fundamental. In the initial state, only this bar is present, resulting in an overall sine wave osc. As you bring more overtones, the sound gets richer. Additive synthesis is capable of creating timbres which are not possible with subtractive synthesis.
 
 \begin{tcolorbox}[colback=yellow!10!white,
         colframe=white!20!black,


### PR DESCRIPTION
Hi @TheWaveWarden,

I just started using Odin2 and I love how it sounds. Thank you so much for making it!

I spotted a typo in a tooltip so I thought I may as well create a PR. I did some spellchecking on the other tooltips and on the tex files for the manual; this PR contains the resulting typo fixes.

I looked into the end of file changes and I believe they are all adding newlines at the end of files which already had Unix line endings but no final newline, which seems OK to me. If it would be better to remove those final newlines just let me know :)

Thanks again for making Odin2!